### PR TITLE
Add a kotlin DSL definition for the build feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,17 @@ to assume roles needed by build steps. Build configurations add a build feature
 configured like so:
 
 ```kotlin
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.awsAssumeRole
+
+// ...
+
 features {
-    feature {
-        type = "awsrole"
-        param("awsrole.roleArn", "arn:aws:iam::123456789012:role/ApiDeployer")
-        param("awsrole.sessionTags", """
+    awsAssumeRole {
+        roleArn = "arn:aws:iam::123456789012:role/ApiDeployer"
+        sessionTags = """
             teamcity.build.id=%teamcity.build.id%
             teamcity.build.triggeredBy.username=%teamcity.build.triggeredBy.username%
-        """.trimIndent())
+        """.trimIndent()
     }
 }
 ```
@@ -57,12 +60,12 @@ The compiled plugin ZIP can be downloaded from the [Releases][releases] tab.
 ## Notes
 
 * You can specify role [session tags][session-tags] using the optional
-  parameters of the form `param("awsrole.sessionTags", "projectId=%teamcity.project.id%")`.
+  parameters of the form `sessionTags = "projectId=%teamcity.project.id%"`.
   As per the linked AWS docs, this requires the assumed role's trust policy to
   allow `sts:TagSession`.
   
 * Both the default role session name and external ID naming schemes can be
-  overridden using parameters `awsrole.sessionName` and `awsrole.externalId`
+  overridden using parameters `sessionName` and `externalId`
   respectively. 
 
 * An IAM role session name has a maximum length of 64 characters. TeamCity project

--- a/build/plugin-assembly.xml
+++ b/build/plugin-assembly.xml
@@ -15,6 +15,15 @@
          <outputDirectory>agent</outputDirectory>
      </file> 
   </files>
+  <fileSets>
+    <fileSet>
+      <directory>../kotlin-dsl/</directory>
+      <outputDirectory>kotlin-dsl</outputDirectory>
+      <includes>
+        <include>*.xml</include>
+      </includes>
+    </fileSet>
+  </fileSets>
   <moduleSets>
     <moduleSet>
        <useAllReactorProjects>true</useAllReactorProjects>
@@ -26,11 +35,14 @@
            <outputDirectory>server</outputDirectory>
            <unpack>false</unpack>
            <dependencySets>
-               <dependencySet>
-                    <includes>
-                         <include>*</include>
-                    </includes>
-               </dependencySet>
+             <dependencySet>
+               <includes>
+                 <include>*</include>
+               </includes>
+               <excludes>
+                 <exclude>org.slf4j:*</exclude>
+               </excludes>
+             </dependencySet>
            </dependencySets>
        </binaries>
     </moduleSet>

--- a/kotlin-dsl/AwsRole.xml
+++ b/kotlin-dsl/AwsRole.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dsl-extension kind="buildFeature" type="awsrole" generateDslJar="true">
+    <class name="AwsAssumeRole">
+        <description>
+            A build feature for assuming an AWS role to be used during the build
+        </description>
+    </class>
+    <function name="awsAssumeRole">
+        <description>
+            Assumes an AWS role for use during the build
+        </description>
+    </function>
+    <params>
+        <param name="awsrole.roleArn" dslName="roleArn">
+            <description>AWS ARN of the role to assume</description>
+        </param>
+        <param name="awsrole.externalId" dslName="externalId">
+            <description>The external ID used when requesting the role session</description>
+        </param>
+        <param name="awsrole.sessionName" dslName="sessionName">
+            <description>The session name used when requesting the role session</description>
+        </param>
+        <param name="awsrole.sessionTags" dslName="sessionTags">
+            <description>Tags applied to the assumed session</description>
+        </param>
+    </params>
+</dsl-extension>


### PR DESCRIPTION
## What??

Adding in a DSL extension definition file. This allows TeamCity to automatically generate DSL configuration for the build feature