### PR TITLE
Feature: Allow specifying the session duration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 target
+.idea
+*.iml

--- a/awsrole-common/src/main/java/com/glassechidna/teamcity/awsrole/AwsRoleConstants.java
+++ b/awsrole-common/src/main/java/com/glassechidna/teamcity/awsrole/AwsRoleConstants.java
@@ -7,6 +7,7 @@ public class AwsRoleConstants {
     public static final String PARAMETER_PREFIX = "awsrole.";
     public static final String ROLE_ARN_PARAMETER = PARAMETER_PREFIX + "roleArn";
     public static final String LEGACY_ROLE_ARN_PARAMETER = "teamcityAwsRolePluginRoleArn";
+    public static final String SESSION_DURATION_PARAMETER = PARAMETER_PREFIX + "sessionDuration";
     public static final String SESSION_TAGS_PARAMETER = PARAMETER_PREFIX + "sessionTags";
     public static final String EXTERNAL_ID_PARAMETER = PARAMETER_PREFIX + "externalId";
     public static final String SESSION_NAME_PARAMETER = PARAMETER_PREFIX + "sessionName";
@@ -17,6 +18,9 @@ public class AwsRoleConstants {
     public static final String AGENT_ROLE_TAGS_PARAMETER = "env.AWSROLE_TAGS";
 
     public static final Integer MAXIMUM_ROLE_SESSION_NAME_LENGTH = 64;
+    public static final Integer MINIMUM_SESSION_DURATION_SECONDS = 900; // 15 minutes
+    public static final Integer MAXIMUM_SESSION_DURATION_SECONDS = 43200; // 12 hours
+    public static final Integer DEFAULT_SESSION_DURATION_SECONDS = MINIMUM_SESSION_DURATION_SECONDS;
     public static final String DEFAULT_EXTERNAL_ID = "%system.teamcity.buildType.id%";
     public static final String DEFAULT_SESSION_NAME = String.format("%s_%s", DEFAULT_EXTERNAL_ID, "%system.build.number%");
 }

--- a/awsrole-common/src/main/java/com/glassechidna/teamcity/awsrole/AwsRoleUtil.java
+++ b/awsrole-common/src/main/java/com/glassechidna/teamcity/awsrole/AwsRoleUtil.java
@@ -23,6 +23,15 @@ public class AwsRoleUtil {
         return params.getOrDefault(AwsRoleConstants.EXTERNAL_ID_PARAMETER, "");
     }
 
+    public static Integer getSessionDuration(Map<String, String> params) {
+        String strDuration = params.get(AwsRoleConstants.SESSION_DURATION_PARAMETER);
+        Integer duration = AwsRoleConstants.DEFAULT_SESSION_DURATION_SECONDS;
+        if (strDuration != null) {
+            duration = Integer.parseInt(strDuration);
+        }
+        return duration;
+    }
+
     public static String getSessionName(Map<String, String> params) {
         String sessionName = params.getOrDefault(AwsRoleConstants.SESSION_NAME_PARAMETER, "");
 

--- a/awsrole-server/src/main/java/com/glassechidna/teamcity/awsrole/AwsRoleFeature.java
+++ b/awsrole-server/src/main/java/com/glassechidna/teamcity/awsrole/AwsRoleFeature.java
@@ -50,6 +50,11 @@ public class AwsRoleFeature extends BuildFeature {
                 invalid.add(new InvalidProperty(AwsRoleConstants.ROLE_ARN_PARAMETER,  "AWS Role ARN is required"));
             }
 
+            Integer sessionDuration = AwsRoleUtil.getSessionDuration(params);
+            if (sessionDuration < AwsRoleConstants.MINIMUM_SESSION_DURATION_SECONDS || sessionDuration > AwsRoleConstants.MAXIMUM_SESSION_DURATION_SECONDS) {
+                invalid.add(new InvalidProperty(AwsRoleConstants.SESSION_DURATION_PARAMETER, "AWS Role session duration must be within the valid durations for this role"));
+            }
+
             return invalid;
         };
     }
@@ -61,6 +66,8 @@ public class AwsRoleFeature extends BuildFeature {
         builder.append(String.format("Role ARN: %s\n", AwsRoleUtil.getRoleArn(params)));
         builder.append(String.format("External Id: %s\n", AwsRoleUtil.getExternalId(params)));
         builder.append(String.format("Session Name: %s\n", AwsRoleUtil.getSessionName(params)));
+        builder.append(String.format("Duration: %s seconds\n", AwsRoleUtil.getSessionDuration(params)));
+
 
         List<Tag> tags = AwsRoleUtil.getSessionTags(params);
 
@@ -80,6 +87,7 @@ public class AwsRoleFeature extends BuildFeature {
         Map<String, String> defaults = new HashMap<>();
         defaults.put(AwsRoleConstants.EXTERNAL_ID_PARAMETER, AwsRoleConstants.DEFAULT_EXTERNAL_ID);
         defaults.put(AwsRoleConstants.SESSION_NAME_PARAMETER, AwsRoleConstants.DEFAULT_SESSION_NAME);
+        defaults.put(AwsRoleConstants.SESSION_DURATION_PARAMETER, AwsRoleConstants.DEFAULT_SESSION_DURATION_SECONDS.toString());
         return defaults;
     }
 

--- a/awsrole-server/src/main/java/com/glassechidna/teamcity/awsrole/AwsRoleParametersProvider.java
+++ b/awsrole-server/src/main/java/com/glassechidna/teamcity/awsrole/AwsRoleParametersProvider.java
@@ -16,4 +16,9 @@ public class AwsRoleParametersProvider {
     public String getSessionName() {
         return AwsRoleConstants.SESSION_NAME_PARAMETER;
     }
+
+    public String getSessionDuration() {
+        return AwsRoleConstants.SESSION_DURATION_PARAMETER;
+    }
+
 }

--- a/awsrole-server/src/main/java/com/glassechidna/teamcity/awsrole/Injector.java
+++ b/awsrole-server/src/main/java/com/glassechidna/teamcity/awsrole/Injector.java
@@ -58,12 +58,14 @@ public class Injector implements ParametersPreprocessor {
             String roleArn = AwsRoleUtil.getRoleArn(resolved);
             String externalId = AwsRoleUtil.getExternalId(resolved);
             String sessionName = AwsRoleUtil.getSessionName(resolved);
+            Integer sessionDuration = AwsRoleUtil.getSessionDuration(resolved);
 
             List<Tag> tags = AwsRoleUtil.getSessionTags(resolved);
 
             AssumeRoleRequest request = AssumeRoleRequest.builder()
                     .roleArn(roleArn)
                     .roleSessionName(sessionName)
+                    .durationSeconds(sessionDuration)
                     .externalId(externalId)
                     .tags(tags)
                     .build();

--- a/awsrole-server/src/main/resources/buildServerResources/awsRoleFeature.jsp
+++ b/awsrole-server/src/main/resources/buildServerResources/awsRoleFeature.jsp
@@ -14,35 +14,52 @@
 </tr>
 <tr>
     <th>
-        <label for="${params.getRoleArn()}"> Role ARN: <l:star/></label>
+        <label for="${params.roleArn}"> Role ARN: <l:star/></label>
     </th>
     <td>
-        <props:textProperty name="<%=params.getRoleArn()%>" className="longField"/>
-        <span class="error" id="error_${params.getRoleArn()}"></span>
+        <props:textProperty name="${params.roleArn}" className="longField"/>
+        <span class="error" id="error_${params.roleArn}"></span>
     </td>
 </tr>
 <tr>
     <th>
-        <label for="${params.getExternalId()}">External ID:</label>
+        <label for="${params.externalId}">External ID:</label>
     </th>
     <td>
-        <props:textProperty name="<%=params.getExternalId()%>" className="longField"/>
+        <props:textProperty name="${params.externalId}" className="longField"/>
     </td>
 </tr>
 <tr>
     <th>
-        <label for="${params.getSessionName()}">Session Name:</label>
+        <label for="${params.sessionName}">Session Name:</label>
     </th>
     <td>
-        <props:textProperty name="<%=params.getSessionName()%>" className="longField"/>
+        <props:textProperty name="${params.sessionName}" className="longField"/>
     </td>
 </tr>
 <tr>
     <th>
-        <label for="${params.getSessionTags()}">Session Tags:</label>
+        <label for="${params.sessionDuration}">Session Duration:</label>
     </th>
     <td>
-        <props:multilineProperty cols="40" rows="6" linkTitle="Session Tags" name="<%=params.getSessionTags()%>" className="longField"/>
+        <props:selectProperty name="${params.sessionDuration}" className="longField">
+            <props:option value="900">15 Minutes</props:option>
+            <props:option value="1600">30 Minutes</props:option>
+            <props:option value="3600">1 Hour</props:option>
+            <props:option value="7200">2 Hours</props:option>
+            <props:option value="14400">4 Hours</props:option>
+            <props:option value="28800">8 Hours</props:option>
+            <props:option value="43200">12 Hours</props:option>
+        </props:selectProperty>
+        <span class="error" id="error_${params.sessionDuration}"></span>
+    </td>
+</tr>
+<tr>
+    <th>
+        <label for="${params.sessionTags}">Session Tags:</label>
+    </th>
+    <td>
+        <props:multilineProperty cols="40" rows="6" linkTitle="Session Tags" name="${params.sessionTags}" className="longField"/>
         <span class="smallNote">Newline seperated list of tags in the format key=value</span>
     </td>
 </tr>

--- a/kotlin-dsl/AwsRole.xml
+++ b/kotlin-dsl/AwsRole.xml
@@ -20,6 +20,9 @@
         <param name="awsrole.sessionName" dslName="sessionName">
             <description>The session name used when requesting the role session</description>
         </param>
+        <param name="awsrole.sessionDuration" dslName="sessionDuration">
+            <description>The duration of the assume role session in seconds</description>
+        </param>
         <param name="awsrole.sessionTags" dslName="sessionTags">
             <description>Tags applied to the assumed session</description>
         </param>


### PR DESCRIPTION
## What??

Allows users to specify the session duration, defaulting to 15 minutes

## Why??

By default sessions last an hour, that's a long time for access keys that may only be needed for a 5 minute build (sadly 15 minutes is the minimum), while some builds may also take much longer than 1 hour so this caters for those as well